### PR TITLE
Reduce code for generic

### DIFF
--- a/src/IO/interfile.cxx
+++ b/src/IO/interfile.cxx
@@ -1441,7 +1441,8 @@ write_basic_interfile_PDFS_header(const string& header_file_name,
             }
 
         const Scanner& scanner = *proj_data_info_sptr->get_scanner_ptr();
-          if (fabs(proj_data_info_sptr->get_ring_radius()-
+#if 0 // KT commented out. currently no get_ring_radius() anymore
+        if (fabs(proj_data_info_sptr->get_ring_radius()-
         scanner.get_effective_ring_radius()) > .1)
       warning("write_basic_interfile_PDFS_header: inconsistent effective ring radius:\n"
          "\tproj_data_info has %g, scanner has %g.\n"
@@ -1449,6 +1450,7 @@ write_basic_interfile_PDFS_header(const string& header_file_name,
          "\tYou will have a problem reading this data back in.",
          proj_data_info_sptr->get_ring_radius(),
          scanner.get_effective_ring_radius());
+#endif
           if (fabs(proj_data_info_sptr->get_ring_spacing()-
         scanner.get_ring_spacing()) > .1)
        warning("write_basic_interfile_PDFS_header: inconsistent ring spacing:\n"
@@ -1490,20 +1492,6 @@ write_basic_interfile_PDFS_header(const string& header_file_name,
               }
 
               const Scanner& scanner = *proj_data_info_sptr->get_scanner_ptr();
-              if (fabs(proj_data_info_sptr->get_ring_radius() - scanner.get_effective_ring_radius()) > .1)
-              	 warning("write_basic_interfile_PDFS_header: inconsistent effective ring radius:\n"
-              		 "\tproj_data_info has %g, scanner has %g.\n"
-              		 "\tThis really should not happen and signifies a bug.\n"
-              		 "\tYou will have a problem reading this data back in.",
-              		 proj_data_info_sptr->get_ring_radius(),
-              		 scanner.get_effective_ring_radius());
-              if (fabs(proj_data_info_sptr->get_ring_spacing() - scanner.get_ring_spacing()) > .1)
-              	 warning("write_basic_interfile_PDFS_header: inconsistent ring spacing:\n"
-              		 "\tproj_data_info has %g, scanner has %g.\n"
-              		 "\tThis really should not happen and signifies a bug.\n"
-              		 "\tYou will have a problem reading this data back in.",
-              		 proj_data_info_sptr->get_ring_spacing(),
-              		 scanner.get_ring_spacing());
 
               output_header << scanner.parameter_info();
 

--- a/src/buildblock/ProjDataInfoGeneric.cxx
+++ b/src/buildblock/ProjDataInfoGeneric.cxx
@@ -61,215 +61,12 @@ ProjDataInfoGeneric(const shared_ptr<Scanner>& scanner_ptr,
                         const VectorWithOffset<int>& min_ring_diff_v,
                         const VectorWithOffset<int>& max_ring_diff_v,
                         const int num_views,const int num_tangential_poss)
-  :ProjDataInfo(scanner_ptr,num_axial_pos_per_segment,
-                num_views,num_tangential_poss),
-   min_ring_diff(min_ring_diff_v),
-   max_ring_diff(max_ring_diff_v)
+  :ProjDataInfoCylindrical(scanner_ptr,num_axial_pos_per_segment,
+                           min_ring_diff_v, max_ring_diff_v, num_views,num_tangential_poss)
 {
-
-  azimuthal_angle_sampling = static_cast<float>(_PI/num_views);
-  ring_radius.resize(0,0);
-  ring_radius[0] = get_scanner_ptr()->get_effective_ring_radius();
-  ring_spacing= get_scanner_ptr()->get_ring_spacing() ;
-
-  // TODO this info should probably be provided via the constructor, or at
-  // least by Scanner.
-  sampling_corresponds_to_physical_rings =
-    scanner_ptr->get_type() != Scanner::HiDAC;
-
-
-  assert(min_ring_diff.get_length() == max_ring_diff.get_length());
-  assert(min_ring_diff.get_length() == num_axial_pos_per_segment.get_length());
-
-  // check min,max ring diff
-  {
-    for (int segment_num=get_min_segment_num(); segment_num<=get_max_segment_num(); ++segment_num)
-      if (min_ring_diff[segment_num]> max_ring_diff[segment_num])
-      {
-        warning("ProjDataInfoGeneric: min_ring_difference %d is larger than max_ring_difference %d for segment %d. "
-          "Swapping them around",
-          min_ring_diff[segment_num], max_ring_diff[segment_num], segment_num);
-        swap(min_ring_diff[segment_num], max_ring_diff[segment_num]);
-      }
-  }
-
-  initialise_ring_diff_arrays();
 }
 
-/* warning In cylindrical geometry m_offset is calculated based on ring_spacing,
- then it is used to caculate ax_pos_num_offset and segment_axial_pos_to_ring1_plus_ring2.
- For generic geometry, m_offset has been removed and the above mentioned variables are
- calculated independant of m_offset.*/
-void
-ProjDataInfoGeneric::
-initialise_ring_diff_arrays() const
-{
-
-  // check min,max ring diff
-  {
-    // check is necessary here again because of set_min_ring_difference()
-    // we do not swap here because that would require the min/max_ring_diff arrays to be mutable as well
-    for (int segment_num=get_min_segment_num(); segment_num<=get_max_segment_num(); ++segment_num)
-      if (min_ring_diff[segment_num]> max_ring_diff[segment_num])
-      {
-        error("ProjDataInfoGeneric: min_ring_difference %d is larger than "
-	      "max_ring_difference %d for segment %d.",
-          min_ring_diff[segment_num], max_ring_diff[segment_num], segment_num);
-      }
-  }
-
-  // initialise ax_pos_num_offset
-  if (sampling_corresponds_to_physical_rings)
-  {
-    const int num_rings = get_scanner_ptr()->get_num_rings();
-    ax_pos_num_offset =
-      VectorWithOffset<int>(get_min_segment_num(),get_max_segment_num());
-
-      /* ax_pos_num will be determined by looking at ring1+ring2.
-       This also works for axially compressed data (i.e. span) as
-       ring1+ring2 is constant for all ring-pairs combined into 1
-       segment,ax_pos.
-
-       Ignoring the difficulties of axial compression for a second, it is clear that
-       for a given bin, there will be 2 rings as follows:
-         ring2 = get_m(bin)/ring_spacing  + ring_diff/2 + (num_rings-1)/2
-         ring1 = get_m(bin)/ring_spacing  - ring_diff/2 + (num_rings-1)/2
-       This follows from the fact that get_m() returns the z position
-       in millimeter of the middle of the LOR w.r.t. the middle of the scanner.
-       The (num_rings-1)/2 shifts the origin such that the first ring has
-       ring_num==0.
-
-       From the above, it follows that
-         ring1+ring2=2*get_m(bin)/ring_spacing + (num_rings-1)
-       Finally, we use the formula for get_m to obtain
-         ring1+ring2=2*ax_pos_num/get_num_axial_poss_per_ring_inc(segment_num)
-	             -2*m_offset[segment_num]/ring_spacing + (num_rings-1)
-       Solving this for ax_pos_num:
-         ax_pos_num = (ring1+ring2-(num_rings-1)
-                       + 2*m_offset[segment_num]/ring_spacing
-		      ) * get_num_axial_poss_per_ring_inc(segment_num)/2
-
-       We could plug m_offset in to obtain
-         ax_pos_num = (ring1+ring2-(num_rings-1)
-		      ) * get_num_axial_poss_per_ring_inc(segment_num)/2.
-                      +
-		      (get_max_axial_pos_num(segment_num)
-		        + get_min_axial_pos_num(segment_num) )/2.
-       this formula is easy to understand, but we don't use it as
-       at some point somebody might change m_offset
-       and forget to change this code...
-       (also, the form above would need float division and then rounding)
-       */
-    for (int segment_num=get_min_segment_num(); segment_num<=get_max_segment_num(); ++segment_num)
-    {
-		const float ax_pos_num_offset_float = (num_rings-1) -
-				(get_max_axial_pos_num(segment_num) +
-				get_min_axial_pos_num(segment_num))
-				/get_num_axial_poss_per_ring_inc(segment_num);
-        ax_pos_num_offset[segment_num] = round(ax_pos_num_offset_float);
-        // check that it was integer
-        if (fabs(ax_pos_num_offset[segment_num] - ax_pos_num_offset_float) > 1E-4)
-		{
- 	       error("ProjDataInfoGeneric: in segment %d, the axial positions\n"
- 	       "do not correspond to the usual locations between physical rings.\n"
- 	       "This is suspicious and can make things go wrong in STIR, so I abort.\n"
- 	       "Check the number of axial positions in this segment.",
- 	       segment_num);
-		}
-
-      if (get_num_axial_poss_per_ring_inc(segment_num)==1)
-	      {
-          // check that we'll get an integer ax_pos_num, i.e.
-          // (ring1+ring2  - ax_pos_num_offset) has to be even, for any
-          // ring1,ring2 in the segment, i.e ring1-ring2 = ring_diff, so
-          // ring1+ring2 = 2*ring2 + ring_diff
-          assert(get_min_ring_difference(segment_num) ==
-          get_max_ring_difference(segment_num));
-          if ((get_max_ring_difference(segment_num) -
-              ax_pos_num_offset[segment_num]) % 2 != 0)
-                warning("ProjDataInfoGeneric: the number of axial positions in "
-                        "segment %d is such that current conventions will place "
-                        "the LORs shifted with respect to the physical rings.",
-                        segment_num);
-          }
-    }
-  }
-  // initialise ring_diff_to_segment_num
-  if (sampling_corresponds_to_physical_rings)
-  {
-    const int min_ring_difference =
-      *min_element(min_ring_diff.begin(), min_ring_diff.end());
-    const int max_ring_difference =
-      *max_element(max_ring_diff.begin(), max_ring_diff.end());
-
-    // set ring_diff_to_segment_num to appropriate size
-    // in principle, the max ring difference would be scanner.num_rings-1, but
-    // in case someone is up to strange things, we take the max of this value
-    // with the max_ring_difference as given in the file
-    ring_diff_to_segment_num =
-      VectorWithOffset<int>(min(min_ring_difference, -(get_scanner_ptr()->get_num_rings()-1)),
-                            max(max_ring_difference, get_scanner_ptr()->get_num_rings()-1));
-    // first set all to impossible value
-    // warning: get_segment_num_for_ring_difference relies on the fact that this value
-    // is larger than get_max_segment_num()
-    ring_diff_to_segment_num.fill(get_max_segment_num()+1);
-
-    for(int ring_diff=min_ring_difference; ring_diff <= max_ring_difference; ++ring_diff)
-    {
-      int segment_num;
-      for (segment_num=get_min_segment_num(); segment_num<=get_max_segment_num(); ++segment_num)
-      {
-        if (ring_diff >= min_ring_diff[segment_num] &&
-            ring_diff <= max_ring_diff[segment_num])
-        {
-   #if 0
-          std::cerr << "ring diff " << ring_diff << " stored in s:" << segment_num << std::endl;
-   #endif
-          ring_diff_to_segment_num[ring_diff] = segment_num;
-          break;
-        }
-      }
-      if (segment_num>get_max_segment_num())
-      {
-        warning("ProjDataInfoGeneric: ring difference %d does not belong to a segment",
-          ring_diff);
-      }
-    }
-  }
-  // initialise segment_axial_pos_to_ring1_plus_ring2
-  if (sampling_corresponds_to_physical_rings)
-  {
-    segment_axial_pos_to_ring1_plus_ring2 =
-      VectorWithOffset<VectorWithOffset<int> >(get_min_segment_num(), get_max_segment_num());
-    for (int s_num=get_min_segment_num(); s_num<=get_max_segment_num(); ++s_num)
-    {
-      const int min_ax_pos_num = get_min_axial_pos_num(s_num);
-      const int max_ax_pos_num = get_max_axial_pos_num(s_num);
-      segment_axial_pos_to_ring1_plus_ring2[s_num].grow(min_ax_pos_num, max_ax_pos_num);
-      for (int ax_pos_num=min_ax_pos_num; ax_pos_num<=max_ax_pos_num; ++ax_pos_num)
-      {
-         // see documentation above for formulas
-        const float ring1_plus_ring2_float =
-					(2*ax_pos_num -
-					 get_max_axial_pos_num(s_num) + get_min_axial_pos_num(s_num))
-					 /get_num_axial_poss_per_ring_inc(s_num) +
-					 get_scanner_ptr()->get_num_rings()-1;
-
-        const int ring1_plus_ring2 =
-          round(ring1_plus_ring2_float);
-        // check that it was integer
-        assert(fabs(ring1_plus_ring2 - ring1_plus_ring2_float) < 1E-4) ;
-        segment_axial_pos_to_ring1_plus_ring2[s_num][ax_pos_num] = ring1_plus_ring2;
-      }
-    }
-  }
-
-  if (sampling_corresponds_to_physical_rings)
-    allocate_segment_axial_pos_to_ring_pair();
-
-  ring_diff_arrays_computed = true;
-}
-
+#if 0
 /*! Default implementation checks common variables. Needs to be overloaded.
  */
 bool
@@ -281,80 +78,18 @@ blindly_equals(const root_type * const that) const
 
   const self_type& proj_data_info = static_cast<const self_type&>(*that);
   return
-    this->azimuthal_angle_sampling == proj_data_info.azimuthal_angle_sampling &&
-    this->ring_radius == proj_data_info.ring_radius &&
-    this->sampling_corresponds_to_physical_rings == proj_data_info.sampling_corresponds_to_physical_rings &&
-    this->ring_spacing == proj_data_info.ring_spacing &&
-    this->min_ring_diff == proj_data_info.min_ring_diff &&
-    this->max_ring_diff == proj_data_info.max_ring_diff;
+    true;
 }
-
-void
-ProjDataInfoGeneric::
-get_ring_pair_for_segment_axial_pos_num(int& ring1,
-					int& ring2,
-					const int segment_num,
-					const int axial_pos_num) const
-{
-  if (!sampling_corresponds_to_physical_rings)
-    error("ProjDataInfoGeneric::get_ring_pair_for_segment_axial_pos_num does not work for this type of sampled data");
-  // can do only span=1 at the moment
-  if (get_min_ring_difference(segment_num) != get_max_ring_difference(segment_num))
-    error("ProjDataInfoGeneric::get_ring_pair_for_segment_axial_pos_num does not work for data with axial compression");
-
-  if (!ring_diff_arrays_computed)
-    initialise_ring_diff_arrays();
-
-  const int ring_diff = get_max_ring_difference(segment_num);
-  const int ring1_plus_ring2= segment_axial_pos_to_ring1_plus_ring2[segment_num][axial_pos_num];
-
-  // KT 01/08/2002 swapped rings
-  ring1 = (ring1_plus_ring2 - ring_diff)/2;
-  ring2 = (ring1_plus_ring2 + ring_diff)/2;
-  assert((ring1_plus_ring2 + ring_diff)%2 == 0);
-  assert((ring1_plus_ring2 - ring_diff)%2 == 0);
-}
-
-
-void
-ProjDataInfoGeneric::
-set_azimuthal_angle_sampling(const float angle_v)
-{
-	azimuthal_angle_sampling =  angle_v;
-}
-
-//void
-//ProjDataInfoGeneric::
-//set_axial_sampling(const float samp_v, int segment_num)
-//{axial_sampling = samp_v;}
-
+#endif
 
 void
 ProjDataInfoGeneric::
 set_num_views(const int new_num_views)
 {
-  const float old_azimuthal_angle_range =
-    this->get_azimuthal_angle_sampling() * this->get_num_views();
-  base_type::set_num_views(new_num_views);
-  this->azimuthal_angle_sampling = old_azimuthal_angle_range/this->get_num_views();
+  if (new_num_views != get_num_views())
+    error("ProjDataInfoGeneric::set_num_views not supported");
 }
-
-void
-ProjDataInfoGeneric::
-set_min_ring_difference( int min_ring_diff_v, int segment_num)
-{
-  ring_diff_arrays_computed = false;
-  min_ring_diff[segment_num] = min_ring_diff_v;
-}
-
-void
-ProjDataInfoGeneric::
-set_max_ring_difference( int max_ring_diff_v, int segment_num)
-{
-  ring_diff_arrays_computed = false;
-  max_ring_diff[segment_num] = max_ring_diff_v;
-}
-
+#if 0 // TODOBLOCK
 void
 ProjDataInfoGeneric::
 set_ring_spacing(float ring_spacing_v)
@@ -362,131 +97,7 @@ set_ring_spacing(float ring_spacing_v)
   ring_diff_arrays_computed = false;
   ring_spacing = ring_spacing_v;
 }
-
-void
-ProjDataInfoGeneric::
-allocate_segment_axial_pos_to_ring_pair() const
-{
-  segment_axial_pos_to_ring_pair =
-    VectorWithOffset<VectorWithOffset<shared_ptr<RingNumPairs> > >
-    (get_min_segment_num(), get_max_segment_num());
-
-  for (int segment_num = get_min_segment_num();
-       segment_num <= get_max_segment_num();
-       ++segment_num)
-    {
-      segment_axial_pos_to_ring_pair[segment_num].grow(get_min_axial_pos_num(segment_num),
-						       get_max_axial_pos_num(segment_num));
-    }
-}
-
-void
-ProjDataInfoGeneric::
-compute_segment_axial_pos_to_ring_pair(const int segment_num, const int axial_pos_num) const
-{
-  shared_ptr<RingNumPairs> new_el(new RingNumPairs);
-  segment_axial_pos_to_ring_pair[segment_num][axial_pos_num] = new_el;
-
-  RingNumPairs& table =
-    *segment_axial_pos_to_ring_pair[segment_num][axial_pos_num];
-  table.reserve(get_max_ring_difference(segment_num) -
-		get_min_ring_difference(segment_num) + 1);
-
-  /* We compute the lookup-table in a fancy way.
-     We could just as well have a simple loop over all ring pairs and check
-     if it belongs to this segment/axial_pos.
-     The current way is a lot faster though.
-  */
-  const int min_ring_diff = get_min_ring_difference(segment_num);
-  const int max_ring_diff = get_max_ring_difference(segment_num);
-  const int num_rings = get_scanner_ptr()->get_num_rings();
-
-  /* ring1_plus_ring2 is the same for any ring pair that contributes to
-     this particular segment_num, axial_pos_num.
-  */
-  const int ring1_plus_ring2=
-    segment_axial_pos_to_ring1_plus_ring2[segment_num][axial_pos_num];
-
-  /*
-    The ring_difference increments with 2 as the other ring differences do
-    not give a ring pair with this axial_position. This is because
-    ring1_plus_ring2%2 == ring_diff%2
-    (which easily follows by plugging in ring1+ring2 and ring1-ring2).
-    The starting ring_diff is determined such that the above condition
-    is satisfied. You can check it by noting that the
-      start_ring_diff%2
-        == (min_ring_diff + (min_ring_diff+ring1_plus_ring2)%2)%2
-	== (2*min_ring_diff+ring1_plus_ring2)%2
-	== ring1_plus_ring2%2
-  */
-  for(int ring_diff = min_ring_diff + (min_ring_diff+ring1_plus_ring2)%2;
-      ring_diff <= max_ring_diff;
-      ring_diff+=2 )
-    {
-      const int ring1 = (ring1_plus_ring2 - ring_diff)/2;
-      const int ring2 = (ring1_plus_ring2 + ring_diff)/2;
-      if (ring1<0 || ring2 < 0 || ring1>=num_rings || ring2 >= num_rings)
-	continue;
-      assert((ring1_plus_ring2 + ring_diff)%2 == 0);
-      assert((ring1_plus_ring2 - ring_diff)%2 == 0);
-      table.push_back(pair<int,int>(ring1, ring2));
- #ifndef NDEBUG
-      int check_segment_num = 0, check_axial_pos_num = 0;
-      assert(get_segment_axial_pos_num_for_ring_pair(check_segment_num,
-						     check_axial_pos_num,
-						     ring1,
-						     ring2) ==
-	     Succeeded::yes);
-      assert(check_segment_num == segment_num);
-      assert(check_axial_pos_num == axial_pos_num);
- #endif
-    }
-}
-
-void
-ProjDataInfoGeneric::
-set_num_axial_poss_per_segment(const VectorWithOffset<int>& num_axial_poss_per_segment)
-{
-  ProjDataInfo::set_num_axial_poss_per_segment(num_axial_poss_per_segment);
-  ring_diff_arrays_computed = false;
-}
-
-void
-ProjDataInfoGeneric::
-set_min_axial_pos_num(const int min_ax_pos_num, const int segment_num)
-{
-  ProjDataInfo::set_min_axial_pos_num(min_ax_pos_num, segment_num);
-  ring_diff_arrays_computed = false;
-}
-
-void ProjDataInfoGeneric::
-set_max_axial_pos_num(const int max_ax_pos_num, const int segment_num)
-{
-  ProjDataInfo::set_max_axial_pos_num(max_ax_pos_num, segment_num);
-  ring_diff_arrays_computed = false;
-}
-
-void
-ProjDataInfoGeneric::
-reduce_segment_range(const int min_segment_num, const int max_segment_num)
-{
-  ProjDataInfo::reduce_segment_range(min_segment_num, max_segment_num);
-  // reduce ring_diff arrays to new valid size
-  VectorWithOffset<int> new_min_ring_diff(min_segment_num, max_segment_num);
-  VectorWithOffset<int> new_max_ring_diff(min_segment_num, max_segment_num);
-
-  for (int segment_num = min_segment_num; segment_num<= max_segment_num; ++segment_num)
-  {
-    new_min_ring_diff[segment_num] = this->min_ring_diff[segment_num];
-    new_max_ring_diff[segment_num] = this->max_ring_diff[segment_num];
-  }
-
-  this->min_ring_diff = new_min_ring_diff;
-  this->max_ring_diff = new_max_ring_diff;
-
-  // make sure other arrays will be updated if/when necessary
-  this->ring_diff_arrays_computed = false;
-}
+#endif
 
 //! warning Find lor from cartesian coordinates of detector pair
 void
@@ -516,13 +127,14 @@ ProjDataInfoGeneric::parameter_info()  const
   std::ostringstream s;
 #endif
   s << ProjDataInfo::parameter_info();
-  s << "Azimuthal angle increment (deg):   " << get_azimuthal_angle_sampling()*180/_PI << '\n';
-  s << "Azimuthal angle extent (deg):      " << fabs(get_azimuthal_angle_sampling())*get_num_views()*180/_PI << '\n';
+  // TODOBLOCK Cylindrical has the following which doesn't make sense for Generic, so repeat code
+  //s << "Azimuthal angle increment (deg):   " << get_azimuthal_angle_sampling()*180/_PI << '\n';
+  //s << "Azimuthal angle extent (deg):      " << fabs(get_azimuthal_angle_sampling())*get_num_views()*180/_PI << '\n';
 
   s << "ring differences per segment: \n";
   for (int segment_num=get_min_segment_num(); segment_num<=get_max_segment_num(); ++segment_num)
   {
-    s << '(' << min_ring_diff[segment_num]  << ',' << max_ring_diff[segment_num] <<')';
+    s << '(' << get_min_ring_difference(segment_num)  << ',' << get_max_ring_difference(segment_num) <<')';
   }
   s << std::endl;
   return s.str();

--- a/src/buildblock/ProjDataInfoGenericNoArcCorr.cxx
+++ b/src/buildblock/ProjDataInfoGenericNoArcCorr.cxx
@@ -174,15 +174,7 @@ initialise_uncompressed_view_tangpos_to_det1det2() const
 
   const int num_detectors =
     get_scanner_ptr()->get_num_detectors_per_ring();
-
   assert(num_detectors%2 == 0);
-  // check views range from 0 to Pi
-  /*!
-    warning The following assersions are slightly different from cylindrical.
-    because in the function get_phi(bin), get_lor is called.
-  */
-  assert(fabs(Bin(0,0,0,0).view_num()*get_azimuthal_angle_sampling()) < 1.E-4);
-  assert(fabs(Bin(0,get_num_views(),0,0).view_num()*get_azimuthal_angle_sampling() - _PI) < 1.E-4);
 
   const int min_tang_pos_num = -(num_detectors/2)+1;
   const int max_tang_pos_num = -(num_detectors/2)+num_detectors;
@@ -235,11 +227,6 @@ initialise_det1det2_to_uncompressed_view_tangpos() const
     {
       error("Minimum view number should currently be zero to be able to use get_view_tangential_pos_num_for_det_num_pair()");
     }
-
-  // check views range from 0 to Pi
-  //! warning The following assersions are slightly different from cylindrical. See the above function
-  assert(fabs(Bin(0,0,0,0).view_num()*get_azimuthal_angle_sampling()) < 1.E-4);
-  assert(fabs(Bin(0,get_max_view_num()+1,0,0).view_num()*get_azimuthal_angle_sampling() - _PI) < 1.E-4);
 
 
   //const int min_tang_pos_num = -(num_detectors/2);
@@ -328,7 +315,7 @@ get_num_det_pos_pairs_for_bin(const Bin& bin) const
 
 void
 ProjDataInfoGenericNoArcCorr::
-get_all_det_pos_pairs_for_bin(vector<DetectionPositionPair<> >& dps,
+get_all_det_pos_pairs_for_bin(std::vector<DetectionPositionPair<> >& dps,
 			      const Bin& bin) const
 {
   this->initialise_uncompressed_view_tangpos_to_det1det2_if_not_done_yet();

--- a/src/include/stir/ProjDataInfoCylindrical.h
+++ b/src/include/stir/ProjDataInfoCylindrical.h
@@ -122,7 +122,11 @@ public:
    (i.e. no axial compression), while it is half the 
    ring spacing for spanned data.
   */
-  inline float get_axial_sampling(int segment_num) const;
+  virtual inline float get_axial_sampling(int segment_num) const;
+  //! Return if axial sampling makes sense
+  /*! could be \c false for block/generic cases */
+  virtual inline bool axial_sampling_is_uniform() const
+  { return true; }
   
   //! Get average ring difference for the given segment
   inline float get_average_ring_difference(int segment_num) const;

--- a/src/include/stir/ProjDataInfoGeneric.inl
+++ b/src/include/stir/ProjDataInfoGeneric.inl
@@ -41,30 +41,6 @@
 
 START_NAMESPACE_STIR
 
-void
-ProjDataInfoGeneric::
-initialise_ring_diff_arrays_if_not_done_yet() const
-{
-  // for efficiency reasons, use "Double-Checked-Locking(DCL) pattern" with OpenMP atomic operation
-  // OpenMP v3.1 or later required
-  // thanks to yohjp: http://stackoverflow.com/questions/27975737/how-to-handle-cached-data-structures-with-multi-threading-e-g-openmp
-#if defined(STIR_OPENMP) &&  _OPENMP >=201012
-  bool initialised;
-#pragma omp atomic read
-  initialised = ring_diff_arrays_computed;
-
-  if (!initialised)
-#endif
-    {
-#if defined(STIR_OPENMP)
-#pragma omp critical(PROJDATAINFOCYLINDRICALRINGDIFFARRAY)
-#endif
-      {
-        if (!ring_diff_arrays_computed)
-          initialise_ring_diff_arrays();
-      }
-    }
-}
 
 //! find phi from correspoding lor
 float
@@ -116,183 +92,35 @@ ProjDataInfoGeneric::get_tantheta(const Bin& bin) const
 float
 ProjDataInfoGeneric::get_sampling_in_m(const Bin& bin) const
 {
-  return get_axial_sampling(bin.segment_num());
+  // TODOBLOCK
+  return get_scanner_ptr()->get_ring_spacing()/2; // TODO currently restricted to span=1 get_num_axial_poss_per_ring_inc(segment_num);
+  //return get_axial_sampling(bin.segment_num());
 }
 
-/*
-	warning Theta is not uniform anymore, so sampling in t does not make sense anymore.
-	Sampling parameters remained unchanged to be consistent with cylindrical version.
-*/
 float
 ProjDataInfoGeneric::get_sampling_in_t(const Bin& bin) const
 {
-  return get_axial_sampling(bin.segment_num())*get_costheta(bin);
+  // TODOBLOCK
+  return get_scanner_ptr()->get_ring_spacing()/2*get_costheta(bin); // TODO currently restricted to span=1 get_num_axial_poss_per_ring_inc(segment_num);
+  //return get_axial_sampling(bin.segment_num())*get_costheta(bin);
 }
-
-int
-ProjDataInfoGeneric::
-get_num_axial_poss_per_ring_inc(const int segment_num) const
-{
-  return
-    max_ring_diff[segment_num] != min_ring_diff[segment_num] ?
-    2 : 1;
-}
-
-float
-ProjDataInfoGeneric::get_azimuthal_angle_sampling() const
-{return azimuthal_angle_sampling;}
 
 float
 ProjDataInfoGeneric::get_axial_sampling(int segment_num) const
 {
-  return ring_spacing/get_num_axial_poss_per_ring_inc(segment_num);
+  // TODOBLOCK should check sampling
+  return get_ring_spacing()/2; // TODO currently restricted to span=1 get_num_axial_poss_per_ring_inc(segment_num);
 }
 
-float
-ProjDataInfoGeneric::get_average_ring_difference(int segment_num) const
+bool ProjDataInfoGeneric::axial_sampling_is_uniform() const
 {
-  // KT 05/07/2001 use float division here.
-  // In any reasonable case, min+max_ring_diff will be even.
-  // But some day, an unreasonable case will walk in.
-  return (min_ring_diff[segment_num] + max_ring_diff[segment_num])/2.F;
-}
-
-int
-ProjDataInfoGeneric::get_min_ring_difference(int segment_num) const
-{ return min_ring_diff[segment_num]; }
-
-int
-ProjDataInfoGeneric::get_max_ring_difference(int segment_num) const
-{ return max_ring_diff[segment_num]; }
-
-float
-ProjDataInfoGeneric::get_ring_radius() const
-{
-  if (this->ring_radius.get_min_index()!=0 || this->ring_radius.get_max_index()!=0)
-    {
-      // check if all elements are equal
-      for (VectorWithOffset<float>::const_iterator iter=this->ring_radius.begin(); iter!= this->ring_radius.end(); ++iter)
-	{
-	  if (*iter != *this->ring_radius.begin())
-	    error("get_ring_radius called for non-circular ring");
-	}
-    }
-  return *this->ring_radius.begin();
-}
-
-void
-ProjDataInfoGeneric::set_ring_radii_for_all_views(const VectorWithOffset<float>& new_ring_radius)
-{
-  if (new_ring_radius.get_min_index() != this->get_min_view_num() ||
-      new_ring_radius.get_max_index() != this->get_max_view_num())
-    {
-      error("error set_ring_radii_for_all_views: you need to use correct range of view numbers");
-    }
-
-  this->ring_radius = new_ring_radius;
-}
-
-VectorWithOffset<float>
-ProjDataInfoGeneric::get_ring_radii_for_all_views() const
-{
-  if (this->ring_radius.get_min_index()==0 && this->ring_radius.get_max_index()==0)
-    {
-      VectorWithOffset<float> out(this->get_min_view_num(), this->get_max_view_num());
-      out.fill(this->ring_radius[0]);
-      return out;
-    }
-  else
-    return this->ring_radius;
-}
-
-float
-ProjDataInfoGeneric::get_ring_radius( const int view_num) const
-{
-  if (this->ring_radius.get_min_index()==0 && this->ring_radius.get_max_index()==0)
-    return ring_radius[0];
-  else
-    return ring_radius[view_num];
+  // TODOBLOCK should check sampling
+  return true;
 }
 
 float
 ProjDataInfoGeneric::get_ring_spacing() const
-{ return ring_spacing;}
+{ return get_scanner_ptr()->get_ring_spacing();}
 
-int
-ProjDataInfoGeneric::
-get_view_mashing_factor() const
-{
-  // KT 10/05/2002 new assert
-  assert(get_scanner_ptr()->get_num_detectors_per_ring() > 0);
-  // KT 10/05/2002 moved assert here from constructor
-  assert(get_scanner_ptr()->get_num_detectors_per_ring() % (2*get_num_views()) == 0);
-  // KT 28/11/2001 do not pre-store anymore as set_num_views would invalidate it
-  return get_scanner_ptr()->get_num_detectors_per_ring() / (2*get_num_views());
-}
-
-Succeeded
-ProjDataInfoGeneric::
-get_segment_num_for_ring_difference(int& segment_num, const int ring_diff) const
-{
-  if (!sampling_corresponds_to_physical_rings)
-    return Succeeded::no;
-
-  // check currently necessary as reduce_segment does not reduce the size of the ring_diff arrays
-  if (ring_diff > get_max_ring_difference(get_max_segment_num()) ||
-      ring_diff < get_min_ring_difference(get_min_segment_num()))
-    return Succeeded::no;
-
-  this->initialise_ring_diff_arrays_if_not_done_yet();
-
-  segment_num = ring_diff_to_segment_num[ring_diff];
-  // warning: relies on initialise_ring_diff_arrays to set invalid ring_diff to a too large segment_num
-  if (segment_num <= get_max_segment_num())
-    return Succeeded::yes;
-  else
-    return Succeeded::no;
-}
-
-Succeeded
-ProjDataInfoGeneric::
-get_segment_axial_pos_num_for_ring_pair(int& segment_num,
-                                        int& ax_pos_num,
-                                        const int ring1,
-                                        const int ring2) const
-{
-  assert(0<=ring1);
-  assert(ring1<get_scanner_ptr()->get_num_rings());
-  assert(0<=ring2);
-  assert(ring2<get_scanner_ptr()->get_num_rings());
-
-  // KT 01/08/2002 swapped rings
-  if (get_segment_num_for_ring_difference(segment_num, ring2-ring1) == Succeeded::no)
-    return Succeeded::no;
-
-  // see initialise_ring_diff_arrays() for some info
-  ax_pos_num = (ring1 + ring2 - ax_pos_num_offset[segment_num])*
-               get_num_axial_poss_per_ring_inc(segment_num)/2;
-  return Succeeded::yes;
-}
-
-const ProjDataInfoGeneric::RingNumPairs&
-ProjDataInfoGeneric::
-get_all_ring_pairs_for_segment_axial_pos_num(const int segment_num,
-					     const int axial_pos_num) const
-{
-  this->initialise_ring_diff_arrays_if_not_done_yet();
-  if (is_null_ptr(segment_axial_pos_to_ring_pair[segment_num][axial_pos_num]))
-    compute_segment_axial_pos_to_ring_pair(segment_num, axial_pos_num);
-  return *segment_axial_pos_to_ring_pair[segment_num][axial_pos_num];
-}
-
-unsigned
-ProjDataInfoGeneric::
-get_num_ring_pairs_for_segment_axial_pos_num(const int segment_num,
-					     const int axial_pos_num) const
-{
-  return
-    static_cast<unsigned>(
-       this->get_all_ring_pairs_for_segment_axial_pos_num(segment_num,axial_pos_num).size());
-}
 
 END_NAMESPACE_STIR

--- a/src/include/stir/ProjDataInfoGenericNoArcCorr.h
+++ b/src/include/stir/ProjDataInfoGenericNoArcCorr.h
@@ -219,7 +219,7 @@ public:
     arc-corrected data).
   */
   void
-    get_all_det_pos_pairs_for_bin(vector<DetectionPositionPair<> >&,
+    get_all_det_pos_pairs_for_bin(std::vector<DetectionPositionPair<> >&,
 				  const Bin&) const;
 
   //! This gets Bin coordinates for a particular detector pair

--- a/src/recon_buildblock/DataSymmetriesForBins_PET_CartesianGrid.cxx
+++ b/src/recon_buildblock/DataSymmetriesForBins_PET_CartesianGrid.cxx
@@ -183,6 +183,7 @@ find_relation_between_coordinate_systems(int& num_planes_per_scanner_ring,
 }
 #endif
 
+#if 0 // disabled as now derived from Cylindrical
 // overloading for generic case
 static void
 find_relation_between_coordinate_systems(int& num_planes_per_scanner_ring,
@@ -224,6 +225,7 @@ find_relation_between_coordinate_systems(int& num_planes_per_scanner_ring,
                 + num_planes_per_scanner_ring*delta)/2;
     }
 }
+#endif
 
 /*! The DiscretisedDensity pointer has to point to an object of 
   type  DiscretisedDensityOnCartesianGrid (or a derived type).
@@ -380,12 +382,18 @@ DataSymmetriesForBins_PET_CartesianGrid
        this->do_symmetry_swap_segment =
        this->do_symmetry_swap_s = false;
      }
+    if (!dynamic_cast<const ProjDataInfoBlocksOnCylindrical *>(proj_data_info_ptr.get())->axial_sampling_is_uniform())
+      {
+        this->do_symmetry_shift_z = false;
+        this->do_symmetry_swap_segment = false;
+      }
 
+    // TODOBLOCK. should probably not call next function for non-uniform sampling
     find_relation_between_coordinate_systems(
             num_planes_per_scanner_ring,
             num_planes_per_axial_pos,
             axial_pos_to_z_offset,
-            static_cast<const ProjDataInfoBlocksOnCylindrical *>(proj_data_info_ptr.get()),
+            dynamic_cast<const ProjDataInfoCylindrical *>(proj_data_info_ptr.get()),
             cartesian_grid_info_ptr);
   }
     // generic implementation
@@ -429,11 +437,18 @@ DataSymmetriesForBins_PET_CartesianGrid
         this->do_symmetry_shift_z = false;
     }
 
+    if (!dynamic_cast<const ProjDataInfoGeneric *>(proj_data_info_ptr.get())->axial_sampling_is_uniform())
+      {
+        this->do_symmetry_shift_z = false;
+        this->do_symmetry_swap_segment = false;
+      }
+
+    // TODOBLOCK. should probably not call next function for non-uniform sampling
     find_relation_between_coordinate_systems(
           num_planes_per_scanner_ring,
           num_planes_per_axial_pos,
           axial_pos_to_z_offset,
-          static_cast<const ProjDataInfoGeneric *>(proj_data_info_ptr.get()),
+          dynamic_cast<const ProjDataInfoCylindrical *>(proj_data_info_ptr.get()),
           cartesian_grid_info_ptr);
     }
 }


### PR DESCRIPTION
Most of the code in `Generic` case in `Cylindrical` was the same. The `Generic` case assumed a 2D system anyway. So I've cut out a lot of the duplication by deriving `Generic` from `Cylindrical`. In fact, it should be the other way around, but that requires more changes elsewhere. This is left for later. At present, I just "`delete`" some member functions in `Generic` to make clear that
they shouldn't be called (they still can be of course, so this isn't very safe).

Added one new function `axial_sampling_is_uniform()` to `ProjDataInfoCylindrical` (and hence all Generic and Block versions). At present, this is still set to true. It is used by the `DataSymmetries` to disable z-shift symmetry.

Functionality should not have changed with this PR